### PR TITLE
Strict json unmarshalling

### DIFF
--- a/cmd/data_setIntent.go
+++ b/cmd/data_setIntent.go
@@ -8,13 +8,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 
+	dsutils "github.com/sdcio/data-server/pkg/utils"
 	sdcpb "github.com/sdcio/sdc-protos/sdcpb"
+	"github.com/sdcio/sdctl/pkg/utils"
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/encoding/prototext"
-
-	"github.com/sdcio/data-server/pkg/utils"
 )
 
 var intentDeleteFlag bool
@@ -39,17 +38,15 @@ var dataSetIntentCmd = &cobra.Command{
 			req.Delete = true
 		}
 		if intentDefinition != "" {
-			b, err := os.ReadFile(intentDefinition)
-			if err != nil {
-				return err
-			}
+
 			intentDefs := make([]*intentDef, 0)
-			err = json.Unmarshal(b, &intentDefs)
+			err := utils.JsonUnmarshalStrict(intentDefinition, intentDefs)
 			if err != nil {
 				return err
 			}
+
 			for _, idef := range intentDefs {
-				p, err := utils.ParsePath(idef.Path)
+				p, err := dsutils.ParsePath(idef.Path)
 				if err != nil {
 					return err
 				}
@@ -86,7 +83,7 @@ var dataSetIntentCmd = &cobra.Command{
 func init() {
 	dataCmd.AddCommand(dataSetIntentCmd)
 	dataSetIntentCmd.Flags().StringVarP(&intentName, "intent", "", "", "intent name")
-	dataSetIntentCmd.Flags().StringVarP(&intentDefinition, "body", "", "", "intent body")
+	dataSetIntentCmd.Flags().StringVarP(&intentDefinition, "file", "", "", "intent definition file")
 	dataSetIntentCmd.Flags().Int32VarP(&priority, "priority", "", 0, "intent priority")
 	dataSetIntentCmd.Flags().BoolVarP(&deleteFlag, "delete", "", false, "delete intent")
 }

--- a/cmd/datastore_create.go
+++ b/cmd/datastore_create.go
@@ -5,11 +5,10 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"os"
 
 	sdcpb "github.com/sdcio/sdc-protos/sdcpb"
+	"github.com/sdcio/sdctl/pkg/utils"
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/encoding/prototext"
 )
@@ -32,28 +31,24 @@ var datastoreCreateCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		var tg *sdcpb.Target
-		if target != "" {
-			b, err := os.ReadFile(target)
-			if err != nil {
-				return err
-			}
-			tg = &sdcpb.Target{}
-			err = json.Unmarshal(b, tg)
-			if err != nil {
-				return err
-			}
-		}
+
 		req := &sdcpb.CreateDataStoreRequest{
 			Name: datastoreName,
 		}
-		if syncFile != "" {
-			b, err := os.ReadFile(syncFile)
+
+		var tg *sdcpb.Target
+		if target != "" {
+			tg = &sdcpb.Target{}
+			err = utils.JsonUnmarshalStrict(target, tg)
 			if err != nil {
 				return err
 			}
+			req.Target = tg
+		}
+
+		if syncFile != "" {
 			sync := &sdcpb.Sync{}
-			err = json.Unmarshal(b, sync)
+			err = utils.JsonUnmarshalStrict(syncFile, sync)
 			if err != nil {
 				return err
 			}
@@ -69,15 +64,13 @@ var datastoreCreateCmd = &cobra.Command{
 				Owner:    owner,
 				Priority: priority,
 			}
-			req.Target = tg
-			//create a main datastore
+		//create a main datastore
 		default:
 			req.Schema = &sdcpb.Schema{
 				Name:    schemaName,
 				Vendor:  schemaVendor,
 				Version: schemaVersion,
 			}
-			req.Target = tg
 		}
 		fmt.Println("request:")
 		fmt.Println(prototext.Format(req))
@@ -99,4 +92,7 @@ func init() {
 	datastoreCreateCmd.Flags().StringVarP(&owner, "owner", "", "", "candidate owner")
 	datastoreCreateCmd.Flags().Int32VarP(&priority, "priority", "", 0, "candidate priority")
 
+	datastoreCreateCmd.Flags().StringVar(&schemaName, "name", "", "schema name")
+	datastoreCreateCmd.Flags().StringVar(&schemaVendor, "vendor", "", "schema vendor")
+	datastoreCreateCmd.Flags().StringVar(&schemaVersion, "version", "", "schema version")
 }

--- a/cmd/datastore_create.go
+++ b/cmd/datastore_create.go
@@ -91,8 +91,4 @@ func init() {
 	datastoreCreateCmd.Flags().StringVarP(&syncFile, "sync", "", "", "target sync definition file")
 	datastoreCreateCmd.Flags().StringVarP(&owner, "owner", "", "", "candidate owner")
 	datastoreCreateCmd.Flags().Int32VarP(&priority, "priority", "", 0, "candidate priority")
-
-	datastoreCreateCmd.Flags().StringVar(&schemaName, "name", "", "schema name")
-	datastoreCreateCmd.Flags().StringVar(&schemaVendor, "vendor", "", "schema vendor")
-	datastoreCreateCmd.Flags().StringVar(&schemaVersion, "version", "", "schema version")
 }

--- a/cmd/datastore_deviation.go
+++ b/cmd/datastore_deviation.go
@@ -1,0 +1,82 @@
+// Copyright 2024 Nokia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/sdcio/data-server/pkg/utils"
+	sdcpb "github.com/sdcio/sdc-protos/sdcpb"
+	"github.com/spf13/cobra"
+)
+
+// datastoreWatchDeviationCmd represents the watch deviation command
+var datastoreWatchDeviationCmd = &cobra.Command{
+	Use:          "deviations",
+	Short:        "watch deviation datastores",
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		ctx, cancel := context.WithCancel(cmd.Context())
+		defer cancel()
+		dataClient, err := createDataClient(ctx, addr)
+		if err != nil {
+			return err
+		}
+		req := &sdcpb.WatchDeviationRequest{Name: []string{datastoreName}}
+		stream, err := dataClient.WatchDeviations(ctx, req)
+		if err != nil {
+			return err
+		}
+		count := 0
+		for {
+			rsp, err := stream.Recv()
+			if err != nil {
+				return err
+			}
+			switch format {
+			case "json":
+				b, err := json.MarshalIndent(rsp, "", "  ")
+				if err != nil {
+					return err
+				}
+				fmt.Println(string(b))
+			default:
+				switch rsp.Event {
+				case sdcpb.DeviationEvent_START:
+					fmt.Printf("%s: %s: %s\n",
+						rsp.GetName(), rsp.GetIntent(), rsp.GetEvent())
+				case sdcpb.DeviationEvent_END:
+					fmt.Printf("%s: %s: %s\n",
+						rsp.GetName(), rsp.GetIntent(), rsp.GetEvent())
+
+					fmt.Printf("Received %d deviations\n", count)
+					count = 0
+				default:
+					count++
+					fmt.Printf("%s: %s: %s: %s: %s : %s -> %s\n",
+						rsp.GetName(), rsp.GetIntent(), rsp.GetEvent(),
+						rsp.GetReason(), utils.ToXPath(rsp.GetPath(), false),
+						rsp.GetExpectedValue(), rsp.GetCurrentValue())
+				}
+			}
+		}
+	},
+}
+
+func init() {
+	datastoreCmd.AddCommand(datastoreWatchDeviationCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,6 +56,9 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&format, "format", "", "output format")
 	rootCmd.PersistentFlags().IntVar(&maxRcvMsg, "max-rcv-msg", 25165824, "the maximum message size in bytes the client can receive")
 	rootCmd.PersistentFlags().DurationVarP(&timeout, "timeout", "", 60*time.Second, "gRPC rpc timeout")
+	rootCmd.PersistentFlags().StringVar(&schemaName, "name", "", "schema name")
+	rootCmd.PersistentFlags().StringVar(&schemaVendor, "vendor", "", "schema vendor")
+	rootCmd.PersistentFlags().StringVar(&schemaVersion, "version", "", "schema version")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -35,10 +35,6 @@ var schemaCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(schemaCmd)
-	schemaCmd.PersistentFlags().StringVar(&schemaName, "name", "", "schema name")
-	schemaCmd.PersistentFlags().StringVar(&schemaVendor, "vendor", "", "schema vendor")
-	schemaCmd.PersistentFlags().StringVar(&schemaVersion, "version", "", "schema version")
-
 }
 
 func grpcClientDialOpts() []grpc.DialOption {

--- a/pkg/utils/json.go
+++ b/pkg/utils/json.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"encoding/json"
+	"os"
+)
+
+func JsonUnmarshalStrict(file string, strukt interface{}) error {
+	// open the file
+	f, err := os.Open(file)
+	if err != nil {
+		return err
+	}
+	// create a decoder for the files content
+	decoder := json.NewDecoder(f)
+	// enable strict parsing
+	decoder.DisallowUnknownFields()
+	// unmarshall
+	err = decoder.Decode(strukt)
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
set intent and create datastore rely on json files. This is to enable strict unmarshaling of the data.